### PR TITLE
Password Reset Feature

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+SALT=VERUCA

--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,0 @@
-SALT=VERUCA

--- a/app.js
+++ b/app.js
@@ -10,6 +10,9 @@ var path = require('path');
 var routes = require('./routes/index');
 var sassMiddleware = require('node-sass-middleware');
 var session = require('express-session');
+// var flash = require('express-flash');
+// var mongoose = require('mongoose'); // forgot password feature is stubbed for mongodb
+var nodemailer = require('nodemailer');
 
 var app = express();
 
@@ -32,6 +35,7 @@ var corsOptions = {
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'jade');
 
+// app.use(flash());
 app.use(favicon(__dirname + '/public/favicon.ico'));
 app.use(logger('dev'));
 app.use(bodyParser.json());
@@ -48,7 +52,7 @@ app.use(
 app.use(session({
   resave: false,
   saveUninitialized: false,
-  secret: process.env.SESSION_SECRET
+  secret: "121332132"
 }));
 app.use(passport.initialize());
 app.use(passport.session());

--- a/app.js
+++ b/app.js
@@ -52,7 +52,7 @@ app.use(
 app.use(session({
   resave: false,
   saveUninitialized: false,
-  secret: "121332132"
+  secret: process.env.SESSION_SECRET
 }));
 app.use(passport.initialize());
 app.use(passport.session());

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
     "passport": "^0.2.1",
     "passport-local": "^1.0.0",
     "request": "^2.53.0",
-    "serve-favicon": "~2.2.0"
+    "serve-favicon": "~2.2.0",
+    "express-flash": "0.0.2",
+    "async": "~0.9.0",
+    "nodemailer": "~1.3.1",
+    "mongoose": "~3.8.24"
   },
   "engines": {
     "node": "0.10.x",

--- a/public/scss/stylesheets/style.scss
+++ b/public/scss/stylesheets/style.scss
@@ -30,6 +30,25 @@ a {
   }
 }
 
+.container a {
+  color: #345262;
+}
+
+.button-transparent {
+  position: relative;
+  z-index: 2;
+  color: inherit;
+  background-color: transparent;
+  border-radius: 0;
+  border: 1px solid transparent;
+  -webkit-transition-duration: .1s;
+  transition-duration: .1s;
+  -webkit-transition-timing-function: ease-out;
+  transition-timing-function: ease-out;
+  -webkit-transition-property: box-shadow;
+  transition-property: box-shadow;
+}
+
 p {
   font-size: 14px;
 }

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -21,6 +21,23 @@ a {
   a:focus {
     outline: none; }
 
+.container a {
+  color: #345262; }
+
+.button-transparent {
+  position: relative;
+  z-index: 2;
+  color: inherit;
+  background-color: transparent;
+  border-radius: 0;
+  border: 1px solid transparent;
+  -webkit-transition-duration: .1s;
+  transition-duration: .1s;
+  -webkit-transition-timing-function: ease-out;
+  transition-timing-function: ease-out;
+  -webkit-transition-property: box-shadow;
+  transition-property: box-shadow; }
+
 p {
   font-size: 14px; }
 

--- a/routes/forgot.js
+++ b/routes/forgot.js
@@ -1,0 +1,69 @@
+var bcrypt = require('bcrypt');
+var crypto = require('crypto');
+var async = require('async');
+
+module.exports = function(router) {
+  router.get('/forgot', function(req, res) {
+    res.render('forgot', { title: 'Landline | Forgot Password' });
+  });
+
+  router.post('/forgot', function(req, res, next) {
+    // if (!name || !password) {
+    //   return done(new Error('All fields are required'));
+    // }
+    async.waterfall([
+    //   function(done) {
+    //     crypto.randomBytes(20, function(err, buf) {
+    //       var token = buf.toString('hex');
+    //       done(err, token);
+    //     });
+    //   },
+      // function(token, done) {
+        // TODO: Assumes Mongodb
+        // User.findOne({ email: req.body.email }, function(err, user) {
+        //   if (!user) {
+        //     return done(new Error('No account with that email address exists.'));
+        //     // return res.redirect('/forgot');
+        //     // req.flash('error', 'No account with that email address exists.');
+        //   }
+        //   user.save(function(err) {
+        //     done(err, token, user);
+        //   });
+        // });
+
+        // test user
+        // var user = {
+        //     email: req.body.email,
+        //     resetPasswordToken: token,
+        //     resetPasswordExpires: Date.now() + 3600000 // 1 hour
+        //   };
+      // },
+      // function(token, user, done) {
+        // TODO: Assumes sendgrid email is setup
+        // var smtpTransport = nodemailer.createTransport('SMTP', {
+        //   service: 'SendGrid',
+        //   auth: {
+        //     user: '!!! YOUR SENDGRID USERNAME !!!',
+        //     pass: '!!! YOUR SENDGRID PASSWORD !!!'
+        //   }
+        // });
+        // var mailOptions = {
+        //   to: user.email,
+        //   from: 'passwordreset@landline.io',
+        //   subject: 'Landline Password Reset',
+        //   text: 'You are receiving this because you (or someone else) have requested the reset of the password for your account.\n\n' +
+        //     'Please click on the following link, or paste this into your browser to complete the process:\n\n' +
+        //     'http://' + req.headers.host + '/reset/' + token + '\n\n' +
+        //     'If you did not request this, please ignore this email and your password will remain unchanged.\n'
+        // };
+        // smtpTransport.sendMail(mailOptions, function(err) {
+        //   req.flash('info', 'An e-mail has been sent to ' + user.email + ' with further instructions.');
+        //   done(err, 'done');
+        // });
+      // }
+    ], function(err) {
+      if (err) return next(err);
+      res.redirect('/forgot');
+    });
+  });
+};

--- a/routes/index.js
+++ b/routes/index.js
@@ -15,6 +15,8 @@ router.get('/', function(req, res) {
 require('./chat')(router);
 require('./login')(router);
 require('./logout')(router);
+require('./forgot')(router);
+require('./reset')(router);
 require('./signup')(router);
 require('./sso')(router);
 require('./teams')(router);

--- a/routes/reset.js
+++ b/routes/reset.js
@@ -1,0 +1,74 @@
+var async = require('async');
+
+module.exports = function(router) {
+  router.get('/reset/:token', function(req, res) {
+  	// TODO: Assumes Mongodb
+	// User.findOne({
+	// 	resetPasswordToken: req.params.token,
+	// 	resetPasswordExpires: {
+	// 		$gt: Date.now()
+	// 	}
+	// }, function(err, user) {
+	// 	if (!user) {
+	// 		// req.flash('error', 'Password reset token is invalid or has expired.');
+	// 		// return res.redirect('/forgot');
+	// 		return done(new Error('Password reset token is invalid or has expired.'));
+	// 	}
+		res.render('reset', {
+			user: req.user
+		});
+	// });
+  });
+
+  router.post('/reset/:token', function(req, res) {
+	async.waterfall([
+		// function(done) {
+			// TODO: Assumes Mongodb
+			// User.findOne({
+			// 	resetPasswordToken: req.params.token,
+			// 	resetPasswordExpires: {
+			// 		$gt: Date.now()
+			// 	}
+			// }, function(err, user) {
+			// 	if (!user) {
+			// 		req.flash('error', 'Password reset token is invalid or has expired.');
+			// 		return res.redirect('back');
+			// 	}
+
+			// 	user.password = req.body.password;
+			// 	user.resetPasswordToken = undefined;
+			// 	user.resetPasswordExpires = undefined;
+
+			// 	user.save(function(err) {
+			// 		req.logIn(user, function(err) {
+			// 			done(err, user);
+			// 		});
+			// 	});
+			// });
+		// },
+		// function(user, done) {
+		// TODO: Assumes sendgrid email is setup
+		// 	var smtpTransport = nodemailer.createTransport('SMTP', {
+		// 		service: 'SendGrid',
+		// 		auth: {
+		// 			user: '!!! YOUR SENDGRID USERNAME !!!',
+		// 			pass: '!!! YOUR SENDGRID PASSWORD !!!'
+		// 		}
+		// 	});
+		// 	var mailOptions = {
+		// 		to: user.email,
+		// 		from: 'passwordreset@demo.com',
+		// 		subject: 'Your password has been changed',
+		// 		text: 'Hello,\n\n' +
+		// 			'This is a confirmation that the password for your account ' + user.email + ' has just been changed.\n'
+		// 	};
+		// 	smtpTransport.sendMail(mailOptions, function(err) {
+		// 		req.flash('success', 'Success! Your password has been changed.');
+		// 		done(err);
+		// 	});
+		// }
+	], function(err) {
+		res.redirect('/login');
+	});
+  });
+};

--- a/views/forgot.jade
+++ b/views/forgot.jade
@@ -1,0 +1,14 @@
+extends layout
+
+block content
+  div.container
+    div.center.p4
+      if error
+        div.bold.center.p2.mb2.white.bg-red.rounded
+          span=error
+      form.clearfix(action='/forgot', method='POST')
+        label.left Team name
+        input.block.field-light.full-width(type='text', placeholder="Team name", name='name')
+        label.left Email
+        input.block.field-light.full-width(type='text', placeholder='Email', name='email')
+        button.button.primary.left(type='submit') Reset Password

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -9,6 +9,15 @@ html
   body.bg-dark
     nav.clearfix.bg-light.white.sm-show
       div.container
+        //- if messages.error
+        //-   .alert.alert-danger
+        //-     div= messages.error
+        //- if messages.info
+        //-   .alert.alert-info
+        //-     div= messages.info
+        //- if messages.success
+        //-   .alert.alert-success
+        //-   div= messages.success
         div.sm-col
           a(href="/")
             img.p2(src="/images/icon.png", style="max-height: 40px;")

--- a/views/login.jade
+++ b/views/login.jade
@@ -12,3 +12,4 @@ block content
         label.left Password
         input.block.field-light.full-width(type='password', placeholder='Password', name='password')
         button.button.primary.left(type='submit') Submit
+        button.button-transparent.left(type='button', onclick='location.href="/forgot"') Forgot Password?

--- a/views/reset.jade
+++ b/views/reset.jade
@@ -1,0 +1,14 @@
+extends layout
+
+block content
+  div.container
+    div.center.p4
+      if error
+        div.bold.center.p2.mb2.white.bg-red.rounded
+          span=error
+       form.clearfix(action='/forgot', method='POST')
+          label.left(for='password') New Password
+          input.block.field-light.full-width(type='password', name='password', value='', placeholder='New password', autofocus=true)
+          label.left(for='confirm') Confirm Password
+          input.block.field-light.full-width(type='password', name='confirm', value='', placeholder='Confirm password')
+          button.button.primary.left(type='submit') Update Password


### PR DESCRIPTION
Work done:
- Added routes for /reset and /forgot:token
- Added views for /reset and /forgot routes.
- I stubbed out the recovery using mongodb, but you can add in whatever API endpoints you want to use. Also, with assumed support of sendgrid. Nodemailer was added.
- Added a link to the login form that goes to /reset. 
- Added the missing BassCSS .button-transparent class.

03-06-15
- changed .env back to .env.sample
- changed session secret back to process.env.SESSION_SECRET
